### PR TITLE
Added support for high-volume users header requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A minimal-dependency API connector that implements all the API methods of the [S
 var { ShipStation } = require('@apigrate/shipstation');
 
 var ship = new ShipStation('key', 'secret');
+
+// OR, for high-volume accounts
+var ship = new ShipStation('key', 'secret', 'partnerkey'); // partnerkey is optional
 ```
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -26,9 +26,10 @@ class ShipStation {
    * @param {string} apiKey 
    * @param {string} apiSecret
    */
-  constructor(apiKey, apiSecret){
+  constructor(apiKey, apiSecret, partnerKey = null){
     this.apiKey = apiKey;
     this.apiSecret = apiSecret;
+    this.partnerKey = partnerKey; //Optional, only used for High-volume Enabled Partner Accounts.
     this.baseUrl = 'https://ssapi.shipstation.com';
   }
 
@@ -590,6 +591,11 @@ class ShipStation {
         "Authorization" : "Basic " + Buffer.from(`${this.apiKey}:${this.apiSecret}`).toString('base64')
       },
     };
+
+    // only add if a partnerKey was actually provided, Only for High Volume Partner Accounts.
+    if (this.partnerKey) {
+      fetchOpts.headers["x-partner"] = this.partnerKey;
+    }
     
     let qstring = '';
     if(query){


### PR DESCRIPTION
This minor change is to add support for the x-partner header key pair required for high-volume users to bypass the standard 40rpm. This partner-key is provided by ShipStation for users that upgraded their api limit. The x-partner header key pair is required to enable to new limit.